### PR TITLE
core: fix update-field! passing wrong args to update!

### DIFF
--- a/src/clj/firestore_clj/core.clj
+++ b/src/clj/firestore_clj/core.clj
@@ -567,8 +567,8 @@
 (defn update-field!
   "Updates a single field of a document by applying a function to it."
   [^DocumentReference dr field f & args]
-  (update! (firestore dr) dr (fn [data]
-                               (apply update data field f args))))
+  (update! dr (fn [data]
+                (apply update data field f args))))
 
 (defn map!
   "Updates all docs in a vector or query by applying a function to them"

--- a/src/clj/firestore_clj/core.clj
+++ b/src/clj/firestore_clj/core.clj
@@ -567,8 +567,7 @@
 (defn update-field!
   "Updates a single field of a document by applying a function to it."
   [^DocumentReference dr field f & args]
-  (update! dr (fn [data]
-                (apply update data field f args))))
+  (update! dr #(apply update % field f args)))
 
 (defn map!
   "Updates all docs in a vector or query by applying a function to them"


### PR DESCRIPTION
Fixes

```
Execution error (IllegalArgumentException) at firestore-clj.core/firestore (core.clj:108).
No matching clause: com.google.cloud.firestore.FirestoreImpl@69706d8d
```